### PR TITLE
fixes to caching and references

### DIFF
--- a/metka/src/main/java/fi/uta/fsd/metka/ddi/builder/DDIWriteDataDescription.java
+++ b/metka/src/main/java/fi/uta/fsd/metka/ddi/builder/DDIWriteDataDescription.java
@@ -69,7 +69,7 @@ class DDIWriteDataDescription extends DDIWriteSectionBase {
         }
 
         // Get variables data for given language
-        Pair<ReturnResult, RevisionData> revisionDataPair = revisions.getRevisionData(valueFieldPair.getRight().getActualValueFor(language));
+        Pair<ReturnResult, RevisionData> revisionDataPair = revisions.getRevisionData(valueFieldPair.getRight().getActualValueFor(Language.DEFAULT));
         if(revisionDataPair.getLeft() != ReturnResult.REVISION_FOUND) {
             Logger.error(getClass(),
                     "Couldn't find expected variables revision with id: " + valueFieldPair.getRight().getActualValueFor(Language.DEFAULT));

--- a/metka/src/main/java/fi/uta/fsd/metka/mvc/services/impl/ExpertSearchServiceImpl.java
+++ b/metka/src/main/java/fi/uta/fsd/metka/mvc/services/impl/ExpertSearchServiceImpl.java
@@ -98,7 +98,7 @@ public class ExpertSearchServiceImpl implements ExpertSearchService {
         ResultList<RevisionResult> results = collectResults(queryResults.getRight());
         if(results.getResults().size() > LuceneConfig.MAX_RETURNED_RESULTS) {
             results.getResults().removeAll(results.getResults().subList(LuceneConfig.MAX_RETURNED_RESULTS, results.getResults().size()));
-            response.setResults(results);;
+            response.setResults(results);
             response.setResult(ReturnResult.RESULT_SET_TOO_LARGE);
         } else {
             response.setResults(results);

--- a/metka/src/main/java/fi/uta/fsd/metka/storage/repository/RevisionRepository.java
+++ b/metka/src/main/java/fi/uta/fsd/metka/storage/repository/RevisionRepository.java
@@ -109,7 +109,9 @@ public interface RevisionRepository {
 
     @Transactional(readOnly = false) void indexRevision(RevisionKey key);
     @Transactional(readOnly = false) void indexRevisions(RevisionKey key);
-    @Transactional(readOnly = false) void removeRevision(RevisionKey key);
+    @Transactional(readOnly = false) void removeRevisionFromIndex(RevisionKey key);
+
+    @Transactional(readOnly = false)  ReturnResult removeRevision(RevisionKey key);
 
     void sendStudyErrorMessageIfNeeded(RevisionData revision, Configuration configuration);
 

--- a/metka/src/main/java/fi/uta/fsd/metka/storage/repository/RevisionableRepository.java
+++ b/metka/src/main/java/fi/uta/fsd/metka/storage/repository/RevisionableRepository.java
@@ -1,0 +1,42 @@
+/**************************************************************************************
+ * Copyright (c) 2013-2015, Finnish Social Science Data Archive/University of Tampere *
+ *                                                                                    *
+ * All rights reserved.                                                               *
+ *                                                                                    *
+ * Redistribution and use in source and binary forms, with or without modification,   *
+ * are permitted provided that the following conditions are met:                      *
+ * 1. Redistributions of source code must retain the above copyright notice, this     *
+ *    list of conditions and the following disclaimer.                                *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,       *
+ *    this list of conditions and the following disclaimer in the documentation       *
+ *    and/or other materials provided with the distribution.                          *
+ * 3. Neither the name of the copyright holder nor the names of its contributors      *
+ *    may be used to endorse or promote products derived from this software           *
+ *    without specific prior written permission.                                      *
+ *                                                                                    *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND    *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED      *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE             *
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR   *
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES     *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;       *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON     *
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT            *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS      *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                       *
+ **************************************************************************************/
+
+package fi.uta.fsd.metka.storage.repository;
+
+import fi.uta.fsd.metka.model.general.DateTimeUserPair;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+public interface RevisionableRepository {
+
+    @Transactional(readOnly = false) void removeRevisionable(Long id);
+
+    @Transactional(readOnly = false) boolean logicallyRemoveRevisionable(DateTimeUserPair info, Long id);
+
+    @Transactional(readOnly = false) void updateRevisionableRevisionNumber(Long id);
+}

--- a/metka/src/main/java/fi/uta/fsd/metka/storage/repository/impl/RevisionRestoreRepositoryImpl.java
+++ b/metka/src/main/java/fi/uta/fsd/metka/storage/repository/impl/RevisionRestoreRepositoryImpl.java
@@ -80,20 +80,22 @@ public class RevisionRestoreRepositoryImpl implements RevisionRestoreRepository 
     private Cascader cascader;
 
     @Override
+    @CacheEvict(value="info-cache", key="#id")
     public RemoveResult restore(Long id) {
-        return restore(id,null);
+        return this.restore(id,null);
     }
 
+    @Override
     @CacheEvict(value="info-cache", key="#id")
     public RemoveResult restore(Long id, LocalDateTime dt) {
-        Pair<ReturnResult, RevisionableInfo> pair = revisions.getRevisionableInfo(id);
-        if(pair.getLeft() != ReturnResult.REVISIONABLE_FOUND) {
+        RevisionableEntity entity = em.find(RevisionableEntity.class, id);
+
+        if(entity == null) {
             return RemoveResult.NOT_FOUND;
         }
-        if(!pair.getRight().getRemoved()) {
+        if(!entity.getRemoved()) {
             return RemoveResult.NOT_REMOVED;
         }
-        RevisionableEntity entity = em.find(RevisionableEntity.class, id);
 
         if (dt != null) {
             if (!dt.equals(entity.getRemovalDate())) {

--- a/metka/src/main/java/fi/uta/fsd/metka/storage/repository/impl/RevisionableRepositoryImpl.java
+++ b/metka/src/main/java/fi/uta/fsd/metka/storage/repository/impl/RevisionableRepositoryImpl.java
@@ -1,0 +1,72 @@
+/**************************************************************************************
+ * Copyright (c) 2013-2015, Finnish Social Science Data Archive/University of Tampere *
+ *                                                                                    *
+ * All rights reserved.                                                               *
+ *                                                                                    *
+ * Redistribution and use in source and binary forms, with or without modification,   *
+ * are permitted provided that the following conditions are met:                      *
+ * 1. Redistributions of source code must retain the above copyright notice, this     *
+ *    list of conditions and the following disclaimer.                                *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,       *
+ *    this list of conditions and the following disclaimer in the documentation       *
+ *    and/or other materials provided with the distribution.                          *
+ * 3. Neither the name of the copyright holder nor the names of its contributors      *
+ *    may be used to endorse or promote products derived from this software           *
+ *    without specific prior written permission.                                      *
+ *                                                                                    *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND    *
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED      *
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE             *
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR   *
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES     *
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;       *
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON     *
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT            *
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS      *
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                       *
+ **************************************************************************************/
+
+package fi.uta.fsd.metka.storage.repository.impl;
+
+import fi.uta.fsd.metka.model.general.DateTimeUserPair;
+import fi.uta.fsd.metka.storage.entity.RevisionableEntity;
+import fi.uta.fsd.metka.storage.repository.RevisionableRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Repository
+public class RevisionableRepositoryImpl implements RevisionableRepository {
+
+    @PersistenceContext(name = "entityManager")
+    private EntityManager em;
+
+    @CacheEvict(value="info-cache", key="#id")
+    public void removeRevisionable(Long id) {
+        em.remove(em.find(RevisionableEntity.class, id));
+    }
+
+    @CacheEvict(value="info-cache", key="#id")
+    public void updateRevisionableRevisionNumber(Long id) {
+        RevisionableEntity entity = em.find(RevisionableEntity.class, id);
+        entity.setLatestRevisionNo(entity.getCurApprovedNo());
+    }
+
+    @CacheEvict(value="info-cache", key="#id")
+    public boolean logicallyRemoveRevisionable(DateTimeUserPair info, Long id) {
+        RevisionableEntity entity = em.find(RevisionableEntity.class, id);
+
+        //this needs to be checked so that restore-cascade can work appropriately.
+        if (entity.getRemoved()) {
+            return true;
+        }
+
+        entity.setRemoved(true);
+        entity.setRemovalDate(info.getTime());
+        entity.setRemovedBy(info.getUser());
+        return false;
+    }
+
+}

--- a/metka/src/main/java/fi/uta/fsd/metka/storage/variables/impl/PORVariablesParser.java
+++ b/metka/src/main/java/fi/uta/fsd/metka/storage/variables/impl/PORVariablesParser.java
@@ -360,6 +360,7 @@ class PORVariablesParser implements VariablesParser {
             target.getReferences().add(newRow);
             ChangeUtil.insertChange(changeMap, target, newRow);
         } else {
+            row.setRemoved(false);
             target.getReferences().add(row);
         }
 

--- a/metka/src/main/java/fi/uta/fsd/metka/storage/variables/impl/StudyVariablesParserImpl.java
+++ b/metka/src/main/java/fi/uta/fsd/metka/storage/variables/impl/StudyVariablesParserImpl.java
@@ -186,6 +186,12 @@ public class StudyVariablesParserImpl implements StudyVariablesParser {
             updateVariables = true;
         }
 
+        fieldPair = attachment.dataField(ValueDataFieldCall.get(Fields.VARIABLES));
+        if (fieldPair.getRight() == null || !fieldPair.getRight().hasValueFor(Language.DEFAULT) || !fieldPair.getRight().valueForEquals(Language.DEFAULT, variablesData.getKey().getId().toString())) {
+            attachment.dataField(ValueDataFieldCall.set(Fields.VARIABLES, new Value(variablesData.getKey().getId().toString()), Language.DEFAULT));
+            updateVariables = true;
+        }
+
         if(!AuthenticationUtil.isHandler(variablesData)) {
             variablesData.setHandler(AuthenticationUtil.getUserName());
             updateVariables = true;

--- a/metka/src/main/resources/configuration/study_attachment_configuration.json
+++ b/metka/src/main/resources/configuration/study_attachment_configuration.json
@@ -298,7 +298,13 @@
 			"type": "FIELD",
 			"content": "variables"
 		}]
-	}, {
+	},{
+		"type": "REMOVE_DRAFT",
+		"targets": [{
+			"type":"FIELD",
+			"content":"variables"
+		}]
+	},{
 		"type": "RESTORE",
 		"targets": [{
 			"type": "FIELD",

--- a/metka/src/main/webapp/resources/js/modules/uiLocalization.js
+++ b/metka/src/main/webapp/resources/js/modules/uiLocalization.js
@@ -481,6 +481,12 @@ define(function (require) {
                             "&STUDY": {
                                 "default": "aineistolta"
                             },
+                            "&STUDY_VARIABLES": {
+                                "default": "aineistomuuttujilta"
+                            },
+                            "&STUDY_VARIABLE": {
+                                "default": "muuttujalta"
+                            },
                             "&STUDY_ATTACHMENT": {
                                 "default": "aineistoliitteistä"
                             },


### PR DESCRIPTION
fixes problems in method caching where cache-eviction was not triggered when called from within a repository class. Also fixes operations on attachment and vargroup-references and exporting ddi with variables for non-default language.
